### PR TITLE
feat: nifi updated to couster instead of node

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -13,7 +13,7 @@
     "port": "8080"
   },
   "jobUrl": "https://job-manager-3d-dev-discrete-ingestion-db-route-3d-dev.apps.v0h0bdx6.eastus.aroapp.io/jobs",
-  "flowUrl": "http://10.8.1.9:8083/flows",
+  "flowUrl": "http://10.8.1.31:8082/flows",
   "paths": {
     "mountPath": "/home/libotadmin",
     "basePath": "\\\\domtest\\mimi\\archi\\maz\\silver\\libot",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,7 +6,7 @@ service:
   externalPort: 8080
 jobServiceUrl: >-
   https://job-manager-3d-dev-discrete-ingestion-db-route-3d-dev.apps.v0h0bdx6.eastus.aroapp.io/jobs
-flowServiceUrl: 'http://10.8.1.9:8083/flows'
+flowServiceUrl: 'http://10.8.1.31:8082/flows'
 paths:
   mountPath: /home/libotadmin
   basePath: \\domtest\mimi\archi\maz\silver\libot

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -57,7 +57,7 @@ components:
         modelPath:
           type: string
           description: Model files location path
-          example: '\\\\domtest\\mimi\\archi\\maz\\silver\\libot\\NewYork'
+          example: '\\domtest\mimi\archi\maz\silver\libot\NewYork'
         tilesetFilename:
           type: string
           description: Model tileset filename


### PR DESCRIPTION
Nifi to cluster

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         ✔                                                                                 |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                         |
| Chore            | ✔                                                                       |

Further  information:
I updated the nifi to the cluster node.
In addition, I fixed the example of the model path to be without duplicated '\'.